### PR TITLE
Update Rest-Client (KeyError (key not found: :ciphers):)

### DIFF
--- a/stone_ecommerce.gemspec
+++ b/stone_ecommerce.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.homepage = 'http://stone.com.br/'
   s.files = Dir.glob ["README.md", "LICENSE", "lib/**/*.{rb}", "*.gemspec"]
   s.test_files = Dir.glob ["spec/**/*"]
-  s.add_dependency 'rest-client', '~> 1.8', '>= 1.8.0'
+  s.add_dependency 'rest-client', '>= 2.0.2'
   s.add_dependency 'nori', '~> 2.6', '>= 2.6.0'
   s.add_dependency 'gyoku', '~> 1.3', '>= 1.3.1'
   s.add_dependency 'nokogiri', '~> 1.6', '>= 1.6.6.2'


### PR DESCRIPTION
Usando ruby 2.4.0+ a gem rest-client 1.8.0 apresenta erros.

```
KeyError (key not found: :ciphers):
```

Testes feitos mostraram que para ruby 2.4+ a gem rest-client deve ser atualizada para 2.0.2