### PR TITLE
v.1.4.1 - Corrigi problemas de compatibilidades com a gem rest-client + ruby 2.3 + openssl 1.0.2+

### DIFF
--- a/stone_ecommerce.gemspec
+++ b/stone_ecommerce.gemspec
@@ -2,19 +2,27 @@ Gem::Specification.new do |s|
   s.name = 'stone_ecommerce'
   s.summary = 'Stone Ruby Client Library'
   s.description = 'Ruby library for integrating with the Stone payment web services.'
-  s.version = '1.4.0' # Major.Minor.Revision
+  s.version = '1.4.1' # Major.Minor.Revision
   s.author = 'Stone Pagamentos'
   s.email = 'meajuda@stone.com.br'
   s.homepage = 'http://stone.com.br/'
   s.files = Dir.glob ["README.md", "LICENSE", "lib/**/*.{rb}", "*.gemspec"]
   s.test_files = Dir.glob ["spec/**/*"]
-  s.add_dependency 'rest-client', '~> 1.8', '>= 1.8.0'
+  
+  # dependencies
+  s.add_dependency 'rest-client', '>= 1.8.0'
   s.add_dependency 'nori', '~> 2.6', '>= 2.6.0'
   s.add_dependency 'gyoku', '~> 1.3', '>= 1.3.1'
   s.add_dependency 'nokogiri', '~> 1.6', '>= 1.6.6.2'
   s.add_dependency 'ffi', '~> 1.9', '>= 1.9.10'
   s.add_dependency 'bundler', '~> 1.10', '>= 1.10.6'
+
+  # development
   s.add_development_dependency 'rspec', '~> 3.3', '>= 3.3.0'
+
+  # ruby version
   s.required_ruby_version = '>= 2.1.7'
+
+  # license use
   s.license = 'Apache 2.0'
 end


### PR DESCRIPTION
Tive problemas usando 

* ruby 2.3+ 
* openSSL 1.0.2g
* rest-client 1.8.0

Por isso gostaria que fosse aceito esse PR para correção do problema.
Atualmente, tive que fazer um fork do projeto, realizar a alteração na dependência para que funcione para mim.

Agradeço desde já a disposição de todos.
